### PR TITLE
Declare package version explicitly

### DIFF
--- a/Formula/ec2c.rb
+++ b/Formula/ec2c.rb
@@ -1,7 +1,10 @@
 class Ec2c < Formula
+  VRESION = "0.1.1".freeze
+
   desc "Simple AWS EC2 CLI"
   homepage "https://github.com/dtan4/ec2c"
-  url "https://github.com/dtan4/ec2c/releases/download/v0.1.1/ec2c-v0.1.1-darwin-amd64.tar.gz"
+  url "https://github.com/dtan4/ec2c/releases/download/v#{VERSION}/ec2c-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "85d422e4e65b456c11b200603b04429693c3d494f3f531b0791f18f13df5d44f"
 
   def install

--- a/Formula/ec2c.rb
+++ b/Formula/ec2c.rb
@@ -1,5 +1,5 @@
 class Ec2c < Formula
-  VRESION = "0.1.1".freeze
+  VERSION = "0.1.1".freeze
 
   desc "Simple AWS EC2 CLI"
   homepage "https://github.com/dtan4/ec2c"

--- a/Formula/ghrls.rb
+++ b/Formula/ghrls.rb
@@ -1,9 +1,10 @@
 class Ghrls < Formula
-  VERSION = "v0.1.0"
+  VERSION = "0.1.0".freeze
 
   desc "List & Describe GitHub Releases"
   homepage "https://github.com/dtan4/ghrls"
-  url "https://github.com/dtan4/ghrls/releases/download/#{VERSION}/ghrls-#{VERSION}-darwin-amd64.tar.gz"
+  url "https://github.com/dtan4/ghrls/releases/download/v#{VERSION}/ghrls-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "58b246d98f06c3fb052a0b92f2d2ef6b192fbe302d7405f7ea11ef72001f20f6"
 
   def install

--- a/Formula/k8sec.rb
+++ b/Formula/k8sec.rb
@@ -1,9 +1,10 @@
 class K8sec < Formula
-  VERSION = "0.3.1"
+  VERSION = "0.3.1".freeze
 
   desc "CLI tool to manage Kubernetes Secrets easily"
   homepage "https://github.com/dtan4/k8sec"
   url "https://github.com/dtan4/k8sec/releases/download/v#{VERSION}/k8sec-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "7398649043e7a9518ef4865401a78c09805b67f138cb37d729ebb1c230385050"
 
   def install

--- a/Formula/k8stail.rb
+++ b/Formula/k8stail.rb
@@ -1,9 +1,10 @@
 class K8stail < Formula
-  VERSION = "v0.3.0"
+  VERSION = "0.3.0"
 
   desc "`tail -f` experience for Kubernetes Pods"
   homepage "https://github.com/dtan4/k8stail"
-  url "https://github.com/dtan4/k8stail/releases/download/#{VERSION}/k8stail-#{VERSION}-darwin-amd64.tar.gz"
+  url "https://github.com/dtan4/k8stail/releases/download/v#{VERSION}/k8stail-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "d293ab88f7785764f8dec161e6b673549b9a9a2017f912ac57aeddddf4f85238"
 
   def install

--- a/Formula/k8stail.rb
+++ b/Formula/k8stail.rb
@@ -1,5 +1,5 @@
 class K8stail < Formula
-  VERSION = "0.3.0"
+  VERSION = "0.3.0".freeze
 
   desc "`tail -f` experience for Kubernetes Pods"
   homepage "https://github.com/dtan4/k8stail"

--- a/Formula/s3url.rb
+++ b/Formula/s3url.rb
@@ -1,5 +1,5 @@
 class S3url < Formula
-  VERSION = "0.3.1"
+  VERSION = "0.3.1".freeze
 
   desc "Generate S3 object pre-signed URL in one command"
   homepage "https://github.com/dtan4/s3url"

--- a/Formula/s3url.rb
+++ b/Formula/s3url.rb
@@ -1,7 +1,10 @@
 class S3url < Formula
+  VERSION = "0.3.1"
+
   desc "Generate S3 object pre-signed URL in one command"
   homepage "https://github.com/dtan4/s3url"
-  url "https://github.com/dtan4/s3url/releases/download/v0.3.1/s3url-v0.3.1-darwin-amd64.tar.gz"
+  url "https://github.com/dtan4/s3url/releases/download/v#{VERSION}/s3url-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "cabdcea887ec566c00d3a615d8439e299a32f12e70b3a64f1d2a702ac3ca0c59"
 
   def install

--- a/Formula/valec.rb
+++ b/Formula/valec.rb
@@ -1,9 +1,10 @@
 class Valec < Formula
-  VERSION = "v0.5.2"
+  VERSION = "0.5.2"
 
   desc "Handle application secrets securely"
   homepage "https://github.com/dtan4/valec"
-  url "https://github.com/dtan4/valec/releases/download/#{VERSION}/valec-#{VERSION}-darwin-amd64.tar.gz"
+  url "https://github.com/dtan4/valec/releases/download/v#{VERSION}/valec-v#{VERSION}-darwin-amd64.tar.gz"
+  version VERSION
   sha256 "a506596c3e0146ac02aa9ccbb97583f44aa1ee26c74f4d08e28c7cf7a2e3ca55"
 
   def install

--- a/Formula/valec.rb
+++ b/Formula/valec.rb
@@ -1,5 +1,5 @@
 class Valec < Formula
-  VERSION = "0.5.2"
+  VERSION = "0.5.2".freeze
 
   desc "Handle application secrets securely"
   homepage "https://github.com/dtan4/valec"


### PR DESCRIPTION
We have to specify package version explicitly, because Homebrew cannot infer version from tarball URL correctly.

https://github.com/Homebrew/brew/blob/5a67cc4fd66825ef8aa39c8bf6a545c09d0a8b8e/docs/Formula-Cookbook.md#version-detection-fails

> Homebrew tries to automatically determine the version from the url to avoid duplication. If the tarball has an unusual name you may need to manually assign the version.