### PR TITLE
Bump up to v0.5.1 k8stail

### DIFF
--- a/Formula/k8stail.rb
+++ b/Formula/k8stail.rb
@@ -1,11 +1,11 @@
 class K8stail < Formula
-  VERSION = "0.4.0".freeze
+  VERSION = "0.5.1".freeze
 
   desc "`tail -f` experience for Kubernetes Pods"
   homepage "https://github.com/dtan4/k8stail"
   url "https://github.com/dtan4/k8stail/releases/download/v#{VERSION}/k8stail-v#{VERSION}-darwin-amd64.tar.gz"
   version VERSION
-  sha256 "0395b9223f52d5c5fde7048f451e95e88a6818bc0c16ada9f8f22be5af6fd893"
+  sha256 "66cda739f7014ee976a92ba4d32f14956936b5bcd02192dc1e906592167bd714"
 
   def install
     bin.install "k8stail"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ brew tap dtan4/tools
 | [ec2c](https://github.com/dtan4/ec2c) | Simple AWS EC2 CLI | [v0.1.1](https://github.com/dtan4/ec2c/releases/tag/v0.1.1) |
 | [ghrls](https://github.com/dtan4/ghrls) | List & Describe GitHub Reelases | [v0.1.0](https://github.com/dtan4/ghrls/releases/tag/v0.1.0) |
 | [k8sec](https://github.com/dtan4/k8sec) | CLI tool to manage Kubernetes Secrets easily | [v0.5.0](https://github.com/dtan4/k8sec/releases/tag/v0.5.0) |
-| [k8stail](https://github.com/dtan4/k8stail) | `tail -f` experience for Kubernetes Pods | [v0.4.0](https://github.com/dtan4/k8stail/releases/tag/v0.4.0) |
+| [k8stail](https://github.com/dtan4/k8stail) | `tail -f` experience for Kubernetes Pods | [v0.5.1](https://github.com/dtan4/k8stail/releases/tag/v0.5.1) |
 | [s3url](https://github.com/dtan4/s3url) | Generate S3 object pre-signed URL in one command | [v0.3.1](https://github.com/dtan4/s3url/releases/tag/v0.3.1) |
 | [valec](https://github.com/dtan4/valec) | Handle application secrets securely | [v0.5.2](https://github.com/dtan4/valec/releases/tag/v0.5.2) |
 


### PR DESCRIPTION
## WHY && WHAT

k8stail of Latest version is v0.5.1.

ref. https://github.com/dtan4/k8stail/releases/tag/v0.5.1

> dtan4 released this on 27 Apr · 8 commits to master since this release
