### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/Formula/ghrls.rb
+++ b/Formula/ghrls.rb
@@ -6,7 +6,6 @@ class Ghrls < Formula
   desc "List & Describe GitHub Releases"
   homepage "https://github.com/dtan4/ghrls"
   version "0.2.1"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/dtan4/ghrls/releases/download/v0.2.1/ghrls_Darwin_x86_64.tar.gz"

--- a/Formula/s3url.rb
+++ b/Formula/s3url.rb
@@ -3,7 +3,6 @@ class S3url < Formula
   desc "Generate S3 object pre-signed URL in one command"
   homepage "https://github.com/dtan4/s3url"
   version "1.0.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/dtan4/s3url/releases/download/v1.0.1/s3url_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
The option is no longer available

https://github.com/dtan4/homebrew-tools/runs/5432381298?check_suite_focus=true

```
Warning: Treating Formula/ec2c.rb as a formula.
Error: ghrls: Calling bottle :unneeded is disabled! There is no replacement.
Error: Process completed with exit code 1.
```